### PR TITLE
Look for resource files relative to executable

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,15 @@ std::string getParentDirectory(const std::string& fullPath) {
     return "";
 }
 
+std::string getExecutableDirectory() {
+    char buffer[MAX_PATH];
+    GetModuleFileNameA(nullptr, buffer, MAX_PATH);
+    std::string fullPath(buffer);
+    return fullPath.substr(0, fullPath.find_last_of("\\/"));
+}
+
+std::string ROOT_DIR;
+
 int main(int argc, char* argv[]) {
 
     std::string fname;
@@ -47,10 +56,11 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    ROOT_DIR = getExecutableDirectory();
+
     std::string data = loadFile(fname);
 
-    HOST host = getHost(getParentDirectory(argv[0]) + "host.txt");
-
+    HOST host = getHost(ROOT_DIR + "host.txt");
 
     std::thread ws_thread(webserver, fname, data, host.second);
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -23,6 +23,8 @@ void centerSprite(sf::Text &spr, sf::RenderWindow &w)
     spr.setPosition(centerX, centerY);
 }
 
+extern std::string ROOT_DIR;
+
 int showBMP(std::string bmpdata, std::string filename, std::string url) {
     // Create a window
     sf::RenderWindow window(sf::VideoMode(500, 500), "Axon");
@@ -35,7 +37,7 @@ int showBMP(std::string bmpdata, std::string filename, std::string url) {
     }
 
     sf::Font font;
-    if (!font.loadFromFile("static/font/GeistMono-SemiBold.ttf"))
+    if (!font.loadFromFile(ROOT_DIR + "/static/font/GeistMono-SemiBold.ttf"))
     {
         std::cerr << "Unable to load font\n";
         exit(0);


### PR DESCRIPTION
Use GetModuleFileNameA() to get the containing directory path, then use it to construct full resource paths.
Fixes #25 