### PR TITLE
Include PDBs in debug build

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 setlocal
-set PROJECT_ROOT=H:\repos\axon
+set PROJECT_ROOT=C:\repos\Axon
 set VCPKG_ROOT=%PROJECT_ROOT%\vcpkg_installed
 set TRIPLET=x64-windows
 mkdir out
@@ -9,7 +9,7 @@ if "%1"=="debug" (
     mkdir "out\debug\"
     cl src\main.cpp src\nayuki-qr\qrcodegen.cpp src\webserver.cpp src\dataloader.cpp src\qr_to_bmp.cpp src\window.cpp src\gethost.cpp src\randompath.cpp /Fe:out\debug\Axon.exe /Fo:out\debug\ /I "%VCPKG_ROOT%\%TRIPLET%\include" /link /LIBPATH:"%VCPKG_ROOT%\%TRIPLET%\lib" sfml-graphics.lib sfml-window.lib sfml-system.lib
     xcopy src\static out\debug\static /E /I /H /Y
-    xcopy %VCPKG_ROOT%\%TRIPLET%\bin\*.dll out\debug\*.dll /Y
+    xcopy %VCPKG_ROOT%\%TRIPLET%\bin\* out\debug\* /Y
 ) else (
     echo Compiling prod version...
     mkdir "out/prod/"


### PR DESCRIPTION
Instead of only copying dynamic libraries, the debug make process now copies all debugging symbol files too. Only in debug, not prod