### PR TITLE
Settings + Webserver overhaul

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -7,7 +7,7 @@ mkdir out
 if "%1"=="debug" (
     echo Compiling debug version...
     mkdir "out\debug\"
-    cl src\main.cpp src\nayuki-qr\qrcodegen.cpp src\webserver.cpp src\dataloader.cpp src\qr_to_bmp.cpp src\window.cpp src\gethost.cpp src\randompath.cpp /Fe:out\debug\Axon.exe /Fo:out\debug\ /I "%VCPKG_ROOT%\%TRIPLET%\include" /link /LIBPATH:"%VCPKG_ROOT%\%TRIPLET%\lib" sfml-graphics.lib sfml-window.lib sfml-system.lib
+    cl /EHsc src\main.cpp src\nayuki-qr\qrcodegen.cpp src\webserver.cpp src\dataloader.cpp src\qr_to_bmp.cpp src\window.cpp src\gethost.cpp src\randompath.cpp src/settings/settings.cpp /Fe:out\debug\Axon.exe /Fo:out\debug\ /I "%VCPKG_ROOT%\%TRIPLET%\include" /link /LIBPATH:"%VCPKG_ROOT%\%TRIPLET%\lib" sfml-graphics.lib sfml-window.lib sfml-system.lib
     xcopy src\static out\debug\static /E /I /H /Y
     xcopy %VCPKG_ROOT%\%TRIPLET%\bin\* out\debug\* /Y
 ) else (

--- a/src/gethost.cpp
+++ b/src/gethost.cpp
@@ -9,32 +9,6 @@
 #pragma comment(lib, "ws2_32.lib")
 #pragma comment(lib, "iphlpapi.lib")
 
-HOST getHost(std::string filename)
-{
-    HOST host;
-    
-    std::ifstream hostFile(filename);
-    if (!hostFile.is_open())
-    {
-        std::cout << "Unable to open host.txt\nAttempting to get primary adapter ip...";
-        host.first = GetLANIPAddress();
-        if (host.first.empty())
-        {
-            std::cout << "FAILED\n";
-            std::cerr << "Unable to open host.txt, and failed to determine primary adapter ip. Ensure that host.txt exists in the same directory as the Axon executable.";
-        }
-        host.second = 8080;
-        return host;
-    }
-
-    hostFile >> host.first;
-    std::string portbuf;
-    hostFile >> portbuf;
-    host.second = std::stoi(portbuf);
-
-    return host;
-}
-
 std::string GetLANIPAddress() {
     ULONG bufferSize = 0;
     GetAdaptersAddresses(AF_INET, 0, nullptr, nullptr, &bufferSize); // Determine buffer size

--- a/src/gethost.hpp
+++ b/src/gethost.hpp
@@ -1,3 +1,1 @@
-typedef std::pair<std::string, unsigned int> HOST;
 std::string GetLANIPAddress();
-HOST getHost(std::string filename);

--- a/src/randompath.cpp
+++ b/src/randompath.cpp
@@ -1,7 +1,7 @@
 #include <string>
 #include <random>
 
-std::string randomPath() {
+std::string generatePath() {
     // Define the characters to choose from (letters and digits)
     const std::string charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     std::string randomString;

--- a/src/randompath.hpp
+++ b/src/randompath.hpp
@@ -1,1 +1,1 @@
-std::string randomPath();
+std::string generatePath();

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -1,0 +1,65 @@
+#include <fstream>
+#include <iostream>
+#include <string>
+#include "settings.hpp"
+#include "../gethost.hpp"
+
+std::string defaults = 
+    "host=auto\n"
+    "port=8082\n"
+;
+
+void createDefaultSettings(std::string fname)
+{
+    std::ofstream sett_file(fname);
+
+    if (!sett_file.is_open())
+    {
+        std::cerr << "Unable to open file " + fname + ". An attempt to create this file also failed\n";
+        exit(0);
+    }
+
+    sett_file.write(defaults.c_str(), defaults.size());
+    sett_file.close();
+}
+
+AXONSETTINGSCONF loadSettings(std::string fname)
+{
+    AXONSETTINGSCONF settings;
+
+    std::ifstream sett_file(fname);
+    if (!sett_file.is_open())
+    {
+        createDefaultSettings(fname);
+        sett_file.open(fname);
+        if (!sett_file.is_open())
+        {
+            std::cerr << "Unable to open file " + fname;
+            exit(0);
+        }
+    }
+
+    std::string line;
+    std::getline(sett_file, line);
+    do
+    {
+        std::string::size_type eq = line.find('=');
+        if (eq != std::string::npos)
+        {
+            std::string field = line.substr(0, eq);
+            std::string val = line.substr(eq+1, line.size()-1);
+            while (val.back() == '\n' || val.back() == '\r' || val.back() == ' ')
+                val.pop_back();
+            if (field == "port")
+                settings.port = std::stoi(val);
+            if (field == "host")
+                settings.host = val;
+        }
+    } while (std::getline(sett_file, line));
+
+    // Do value processing here
+    if (settings.host == "auto")
+        settings.host = GetLANIPAddress();
+
+    return settings;
+}

--- a/src/settings/settings.hpp
+++ b/src/settings/settings.hpp
@@ -1,0 +1,7 @@
+struct AXONSETTINGSCONF
+{
+    std::string host;
+    unsigned int port;
+};
+
+AXONSETTINGSCONF loadSettings(std::string fname);

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -113,13 +113,6 @@ int webserver(std::string filepath, std::string &data, unsigned int port, std::s
         return 1;
     }
 
-
-
-
-
-
-
-
     //build http_200_response
     std::string ext, content_disposition = "attachment", mimetype = "application/octet-stream";
     ext = getFileExt(getFilename(filepath));
@@ -160,11 +153,6 @@ int webserver(std::string filepath, std::string &data, unsigned int port, std::s
         + "Content-Disposition: inline\r\n"
         + "Connection: close\r\n\r\n"
         + body_404;
-
-
-
-
-
 
     // Main server loop
     std::vector<std::thread> responses;

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -7,7 +7,7 @@
 
 #pragma comment(lib, "Ws2_32.lib")
 
-std::string shortenPath(std::string path)
+std::string getFilename(std::string path)
 {
     while (path.find('/') != std::string::npos)
         path.erase(0, 1);
@@ -41,72 +41,43 @@ std::string getFileExt(std::string fname)
     return fname;
 }
 
-void handleClient(SOCKET clientSocket, std::string filename, std::string &data, std::string url_path, std::string mimetype, std::string sug_cont_dispo) { //suggested content disposition
+void handleClient(SOCKET clientSocket, std::string correct_path, std::string &http_200_response, std::string &http_404_response) { //suggested content disposition
     // Buffer for receiving data
     char buffer[1024] = {0};
     int bytesReceived = recv(clientSocket, buffer, sizeof(buffer) - 1, 0);
-    
     if (bytesReceived == SOCKET_ERROR) {
         std::cerr << "Receive failed with error: " << WSAGetLastError() << std::endl;
         closesocket(clientSocket);
         return;
     }
-
     buffer[bytesReceived] = '\0';
 
-    // Simple HTTP response
-    std::string response_body =
-        "<!DOCTYPE html><html><head><title>For, oh fore</title></head>"
-        "<body><h1>nothing here</h1></body></html>";
-
-    std::string cont_dispo = "inline";
-
-    std::string reqPath = parseRequestPath(buffer);
+    //get the requested url path
+    std::string request_path = parseRequestPath(buffer);
     
-    
-    if (reqPath == std::string(url_path))
+    const char *http_response = http_404_response.c_str();
+    unsigned int http_response_size = http_404_response.size();
+
+    //if requested path matches the correct one, send 200 response, otherwise send 404.
+    if (request_path == std::string(correct_path))
     {
-        //response_type = "application/octet-stream";
-        response_body = data;
-        cont_dispo = sug_cont_dispo;
+        http_response = http_200_response.c_str();
+        http_response_size = http_200_response.size();
     }
-        
-
-    std::string httpResponse =
-        "HTTP/1.1 200 OK\r\n"
-        "Content-Type: " + mimetype + "\r\n"
-        "Content-Length: " + std::to_string(response_body.size()) + "\r\n"
-        + "Content-Disposition: " + cont_dispo + (cont_dispo=="attachment" ? ("; filename="+shortenPath(filename)+"\r\n") : (""))
-        + "Connection: close\r\n\r\n"
-        + response_body;
 
     // Send the response to the client
-    send(clientSocket, httpResponse.c_str(), httpResponse.size(), 0);
+    send(clientSocket, http_response, http_response_size, 0);
 
     // Close the client socket
     closesocket(clientSocket);
 }
 
-int webserver(std::string filename, std::string &data, unsigned int port, std::string url_path) {
+int webserver(std::string filepath, std::string &data, unsigned int port, std::string url_path) {
     WSADATA wsaData;
     SOCKET serverSocket, clientSocket;
     struct sockaddr_in serverAddr, clientAddr;
     int clientAddrLen = sizeof(clientAddr);
 
-    std::string ext, content_disposition = "attachment", mimetype = "application/octet-stream";
-    ext = getFileExt(filename);
-
-    if (ext == "jpg" || ext == "jpeg")
-        mimetype = "image/jpeg";
-    else if (ext == "png")
-        mimetype = "image/png";
-    else if (ext == "pdf")
-        mimetype = "application/pdf";
-    else if (ext == "mp4")
-    {
-        mimetype = "video/mp4";
-        content_disposition = "inline";
-    }
     // Initialize Winsock
     if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
         std::cerr << "WSAStartup failed with error: " << WSAGetLastError() << std::endl;
@@ -142,9 +113,61 @@ int webserver(std::string filename, std::string &data, unsigned int port, std::s
         return 1;
     }
 
-    std::vector<std::thread> responses;
+
+
+
+
+
+
+
+    //build http_200_response
+    std::string ext, content_disposition = "attachment", mimetype = "application/octet-stream";
+    ext = getFileExt(getFilename(filepath));
+
+    std::vector<std::pair<std::vector<std::string>, std::string>> known_types = {
+        {{"jpg", "jpeg"}, "image/jpeg"},
+        {{"png"}, "image/png"},
+        {{"pdf"}, "application/pdf"},
+        {{"mp4"}, "video/mp4"},
+        {{"txt"}, "text/plain"}
+    };
+
+    for (int t = 0; t < known_types.size(); t++)
+    {
+        for (int e = 0; e < known_types[t].first.size(); e++)
+        {
+            if (ext == known_types[t].first[e]) mimetype = known_types[t].second;
+        }
+    }
+
+    std::string http_200_response =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: " + mimetype + "\r\n"
+        "Content-Length: " + std::to_string(data.size()) + "\r\n"
+        //+ "Content-Disposition: " + content_disposition + (content_disposition=="attachment" ? ("; filename=\""+getFilename(filepath)+"\"") : ("")) + "\r\n"
+        + "Content-Disposition: " + content_disposition + (content_disposition=="attachment" ? ("; filename=\""+getFilename(filepath)+"\"") : ("")) + "\r\n"
+        + "Connection: close\r\n\r\n"
+        + data;
+
+    // Simple HTTP response
+    std::string body_404 =
+        "<!DOCTYPE html><html><head><title>Fore, oh fore</title></head>"
+        "<body><h1>404 Not Found</h1>\n<p>check your url path or scan the QR code</p></body></html>";
+    std::string http_404_response =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: text/html\r\n"
+        "Content-Length: " + std::to_string(body_404.size()) + "\r\n"
+        + "Content-Disposition: inline\r\n"
+        + "Connection: close\r\n\r\n"
+        + body_404;
+
+
+
+
+
 
     // Main server loop
+    std::vector<std::thread> responses;
     while (true) {
         // Accept a client socket
         clientSocket = accept(serverSocket, (struct sockaddr*)&clientAddr, &clientAddrLen);
@@ -154,7 +177,7 @@ int webserver(std::string filename, std::string &data, unsigned int port, std::s
         }
 
         // Handle the client request
-        responses.push_back(std::thread(handleClient, clientSocket, filename, std::ref(data), url_path, mimetype, content_disposition));
+        responses.push_back(std::thread(handleClient, clientSocket, url_path, std::ref(http_200_response), std::ref(http_404_response)));
     }
 
     // Cleanup

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -25,7 +25,7 @@ void centerSprite(sf::Text &spr, sf::RenderWindow &w)
 
 extern std::string ROOT_DIR;
 
-int showBMP(std::string bmpdata, std::string filename, std::string url) {
+int createWindow(std::string bmpdata, std::string filename, std::string url) {
     // Create a window
     sf::RenderWindow window(sf::VideoMode(500, 500), "Axon");
 

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -1,1 +1,1 @@
-int showBMP(std::string bmpfile, std::string filename, std::string url);
+int createWindow(std::string bmpfile, std::string filename, std::string url);


### PR DESCRIPTION
- Implements a settings file which can be used to specify options for runtime behavior (currently host, port)
- Overhauled webserver.cpp
  - moved redundant processing from handleClient(...) to webserver(...), so it only needs to be performed once by the listener thread instead of repeatedly on every response thread.
 - Added /EHsc to compiler call, fixing the compiler's complaints about unwind semantics
 - Added comments throughout, and neatened up main.cpp

Fixes #35 
Fixes #27 